### PR TITLE
Switch to TF_IsHolidayActive detour

### DIFF
--- a/addons/sourcemod/gamedata/hwn_cosmetic_enabler.txt
+++ b/addons/sourcemod/gamedata/hwn_cosmetic_enabler.txt
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (C) 2022  Mikusch
  *
  * This program is free software: you can redistribute it and/or modify
@@ -21,6 +21,12 @@
 	{
 		"Signatures"
 		{
+			"TF_IsHolidayActive"
+			{
+				"library"	"server"
+				"linux"		"@_Z18TF_IsHolidayActivei"
+				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x83\x78\x30\x00\x74\x2A\x32\xC0"
+			}
 			"CLogicOnHoliday::InputFire"
 			{
 				"library"	"server"
@@ -30,6 +36,20 @@
 		}
 		"Functions"
 		{
+			"TF_IsHolidayActive"
+			{
+				"signature"	"TF_IsHolidayActive"
+				"callconv"	"cdecl"
+				"return"	"bool"
+				"this"		"ignore"
+				"arguments"
+				{
+					"eHoliday"
+					{
+						"type"	"int"
+					}
+				}
+			}
 			"CLogicOnHoliday::InputFire"
 			{
 				"signature"	"CLogicOnHoliday::InputFire"

--- a/addons/sourcemod/scripting/hwn_cosmetic_enabler.sp
+++ b/addons/sourcemod/scripting/hwn_cosmetic_enabler.sp
@@ -36,7 +36,7 @@ public Plugin myinfo =
 	name = "[TF2] Halloween Cosmetic Enabler",
 	author = "Mikusch",
 	description = "Enables Halloween cosmetics and spells regardless of current holiday",
-	version = "1.2.0",
+	version = "1.3.0",
 	url = "https://github.com/Mikusch/HalloweenCosmeticEnabler"
 }
 

--- a/addons/sourcemod/scripting/hwn_cosmetic_enabler.sp
+++ b/addons/sourcemod/scripting/hwn_cosmetic_enabler.sp
@@ -20,8 +20,6 @@
 #include <tf2_stocks>
 #include <dhooks>
 
-const TFHoliday TFHoliday_None = view_as<TFHoliday>(0);
-
 ConVar tf_enable_halloween_cosmetics;
 ConVar tf_forced_holiday;
 DynamicDetour g_hDetourIsHolidayActive;
@@ -91,15 +89,6 @@ public void OnClientPutInServer(int iClient)
 	
 	if (!IsFakeClient(iClient))
 		ReplicateHolidayToClient(iClient, TFHoliday_HalloweenOrFullMoon);
-}
-
-public void OnClientDisconnect(int iClient)
-{
-	if (!g_bIsEnabled)
-		return;
-	
-	if (!IsFakeClient(iClient))
-		ReplicateHolidayToClient(iClient, TFHoliday_None);
 }
 
 public void OnEntityCreated(int iEntity, const char[] szClassname)


### PR DESCRIPTION
Turns out that the `TF2_OnIsHolidayActive` forward is inaccurate and does not fire for all cases, due to SM hooking the virtual `CTFGameRules::IsHolidayActive` instead of detouring `TF_IsHolidayActive`.

Let's switch to a `TF_IsHolidayActive` detour instead of using the forward.